### PR TITLE
Add gateway config files

### DIFF
--- a/source/gcx_apps/Low_power_room_monitoring_app/gateway_config_files/gateway.env
+++ b/source/gcx_apps/Low_power_room_monitoring_app/gateway_config_files/gateway.env
@@ -1,0 +1,42 @@
+#
+# Select the version of wirepas Gateway to use:
+#   - "latest" (default if  not set): the gateway will use the latest official release,
+#     and at each reboot, the gateway will check if there is a new release to upgrade
+#   - "edge":  the gateway will use the top of gateway master branbch. At each reboot,
+#     the gateway will check if there is a new release to updgrade
+#   - "v1.3.1", "v1.4.0"...: any tag available from docker hub
+#
+GATEWAY_TAG=
+
+# Gateway unique id (used also as mqtt client name)
+# If left blank, id will be automatically generated as a uuid based on your hardware
+# Id can be any string as long as it is unique in your network. 
+WM_GW_ID=my_first_wirepas_gw
+
+#
+# Sink service configuration
+#
+
+# On which port the sink is attached (ex: /dev/ttyACM0 or /dev/ttyAMA0 if using a rpi hat)
+WM_GW_SINK_UART_PORT=/dev/ttyAMA0
+# Uart baudtrate of the sink. It depends on the build configuration of dualmcu_app (ex: 115200, 125000, 1000000)
+# If left blank, baudrate 125000, 115200 and 100000 will be tried successively
+WM_GW_SINK_BITRATE=115200
+
+#
+# Transport service configuration
+#
+
+# If you need more Mqtt settings; please check https://github.com/wirepas/gateway/blob/master/python_transport/wirepas_gateway/utils/argument_tools.py for additional parameters.
+# Address of the broker to connect
+WM_SERVICES_MQTT_HOSTNAME=10.101.46.110
+# MQTT port (usually 8883 for secure access, or 1883 for unsecure)
+WM_SERVICES_MQTT_PORT=1883
+# WM_SERVICES_MQTT_PORT=9002
+# Username to connect to broker
+WM_SERVICES_MQTT_USERNAME=wirepas
+# Password to connect to broker
+WM_SERVICES_MQTT_PASSWORD=!!! Use the mqtt password form the wirepas item in Embedded CC VAULTS in 1Password App !!!
+# Uncomment following line to skip TLS check on brocker (uncomment it for local brocker)
+WM_SERVICES_MQTT_FORCE_UNSECURE=true
+

--- a/source/gcx_apps/Low_power_room_monitoring_app/gateway_config_files/sink.env
+++ b/source/gcx_apps/Low_power_room_monitoring_app/gateway_config_files/sink.env
@@ -1,0 +1,18 @@
+#
+# Initial Sink configuration
+#
+
+# Node address of the sink (Ex: 0x12345 - 32 bits max can be Hex or Decimal)
+WM_CN_NODE_ADDRESS=0x12345
+# Network address (Ex: 0xA1B2C3 - 24bits max  can be Hex or Decimal)
+WM_CN_NETWORK_ADDRESS=0x123456
+# Network channel (Ex: 2 - Valid numbers 1-40)
+WM_CN_NETWORK_CHANNEL=2
+# 16 bytes authentication key for the network (Ex:000102..0F - leave empty if not used)
+WM_CN_AUTHENTICATION_KEY=
+# 16 bytes cipher key for the network (Ex:000102..0F - leave empty if not used)
+WM_CN_CIPHER_KEY=
+
+# Set node role to sink csma-ca (shouldn’t be changed)
+WM_CN_NODE_ROLE="sink csma-ca"
+


### PR DESCRIPTION
These files must be added to the SD-CARD of each raspberry pi (Wirepas Gateway) in the folder `wirepas` under the path: `/boot/wirepas`.
For more information refer to https://github.com/wirepas/raspberry-gateway-image/tree/master